### PR TITLE
Mensaje a la hora de realizar la votación.

### DIFF
--- a/decide/booth/templates/booth/booth.html
+++ b/decide/booth/templates/booth/booth.html
@@ -15,6 +15,20 @@
     </div>
 
     <div id="voting">
+    
+    	{% if start_date == None%}
+        	<p>La votación no ha empezado aún</p>
+        
+        {%else%}
+        	<p>La votación empezó el: {{ start_date }}</p>
+	        
+	        {%if end_date == None%}
+	        	<p>Aún puede votar, no ha finalizado la votación</p>
+	        {% else %}
+	        	<p>Ya no puede votar, la votación se cerró el: {{ end_date }}</p>
+        	 {% endif %}
+        	 
+        {% endif %}
         <a href="#" onClick="decideLogout()">{% trans "logout" %}</a>
         <h2>{{ voting.question.desc }}</h2>
 

--- a/decide/booth/views.py
+++ b/decide/booth/views.py
@@ -4,6 +4,7 @@ from django.http import Http404
 
 from base import mods
 
+import datetime
 
 # TODO: check permissions and census
 class BoothView(TemplateView):
@@ -22,5 +23,18 @@ class BoothView(TemplateView):
         context['store_url'] = settings.APIS.get('store', settings.BASEURL)
         context['auth_url'] = settings.APIS.get('authentication', settings.BASEURL)
         context['KEYBITS'] = settings.KEYBITS
+        
+        context['start_date'] = self.get_format_date(context['voting']['start_date'])
+        context['end_date'] = self.get_format_date(context['voting']['end_date'])
 
         return context
+    
+    def get_format_date(self, fecha):
+        result= None
+        
+        if fecha != None:
+            fecha = fecha.replace("T", " ").replace("Z","")
+            date_time = datetime.datetime.strptime(fecha, '%Y-%m-%d %H:%M:%S.%f')
+            result= date_time.strftime('%d/%m/%Y a las %H:%M:%S')
+        
+        return result


### PR DESCRIPTION
Establecer un mensaje que indique al usuario cuándo puede realizar la votación, para evitar que rellene la votación y no pueda enviarla posteriormente.