### PR TITLE
Habilitar corsheader

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -76,6 +76,7 @@ BASEURL = 'https://decide-europa.herokuapp.com'
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -165,6 +166,11 @@ except ImportError:
 INSTALLED_APPS = INSTALLED_APPS + MODULES
 
 APIS = {}
+
+CORS_ORIGIN_WHITELIST = (
+    'localhost:3000',
+    'localhost:8000'
+)
 
 import django_heroku
 django_heroku.settings(locals())


### PR DESCRIPTION
Se han introducido los cambios solicitados por cabina en el archivo settings.py, este commit está relacionado con la Issue #56.

Se ha habilitado cors para permitir que desde otro dominio se realicen peticiones a nuestra API.