### PR TITLE
Vista para el listado de votaciones

### DIFF
--- a/decide/booth/static/css/style.css
+++ b/decide/booth/static/css/style.css
@@ -110,3 +110,21 @@ body {
 0% { opacity: 0; transform: scale(0.5); }
 100% { opacity: 1; transform: scale(1); }
 }
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th, td {
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even){background-color: #f2f2f2}
+
+th {
+  background-color: #E77F28;
+  color: white;
+}
+

--- a/decide/booth/templates/booth/votings.html
+++ b/decide/booth/templates/booth/votings.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load i18n static %}
+
+{% block content %}
+ <link rel="stylesheet" href="/static/css/style.css">
+<table>
+		<tr>
+		<th>Name</th>
+		<th>Start Date</th>
+		<th>Vote</th>
+		</tr>
+		
+		{% for v in votings %}
+			<tr>
+			<td>{{v.name}}</td>
+			{% if v.start_date is None %}
+			<td>It's not started</td>
+			{% else %}
+			<td>{{v.start_date}}</td>
+			{% endif %}
+			<td><a href='/booth/{{v.id}}/'>Vote</a></td>
+			</tr>
+		{% endfor %}
+		
+	</table>
+
+{% endblock %}

--- a/decide/booth/tests.py
+++ b/decide/booth/tests.py
@@ -1,3 +1,23 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+import random
+from base.tests import BaseTestCase
+from rest_framework.test import APIClient
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+
+from base import mods
+
+# Create your testsfrom django.test import TestCase
+
+class TestBooth(BaseTestCase):
+    
+
+    def test_call_view_votings_authenticated(self):
+    
+        response = self.client.get('/booth/votings/', follow=True) 
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'booth/votings.html')
+
+   

--- a/decide/booth/urls.py
+++ b/decide/booth/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 from .views import BoothView
+from . import views
 
 
 urlpatterns = [
     path('<int:voting_id>/', BoothView.as_view()),
+    path('votings/', views.votings)
 ]

--- a/decide/booth/views.py
+++ b/decide/booth/views.py
@@ -1,6 +1,8 @@
 from django.views.generic import TemplateView
 from django.conf import settings
 from django.http import Http404
+from voting.models import Voting
+from django.shortcuts import render, redirect
 
 from base import mods
 
@@ -38,3 +40,10 @@ class BoothView(TemplateView):
             result= date_time.strftime('%d/%m/%Y a las %H:%M:%S')
         
         return result
+
+def votings(request):
+    votings = Voting.objects.exclude(end_date__isnull = False)
+    
+    return render(request, 'booth/votings.html', {'votings': votings})
+        
+    


### PR DESCRIPTION
Desde el grupo decide-europa-cabina hemos realizado una vista con el listado de votaciones que permancen abiertas.

Esta mejora ha sido realizada por petición del grupo de authentication: [Petición cabina](https://github.com/decide-europa/decide-europa/issues/13)

En el repositorio de cabina, esta petición ha sido tratada en la _issue_: [Vista que lista las votaciones antes de votar.](https://github.com/decide-europa-cabina/decide-europa-cabina/issues/19)

Hemos realizado un _checklist_ con los puntos que debe tener este listado de votaciones

- [ ] - Creamos tres votaciones y las empezamos
- [ ] - Nos vamos al path /booth/votings/ y vemos que nos sale un listado con nuestras votaciones
- [ ] - Debe aparecer el nombre, la fecha en la que empezó (si ha empezado) y un enlace para acceder a la cabina para votar
- [ ] - Le damos al enlace, nos autenticamos si hace falta y vemos que entramos a la vista de la votación